### PR TITLE
Add package importlib-resources to the install requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     statsmodels==0.11.1
     async-exit-stack    # backports for py36
     async-generator     # backports for py36
+    importlib-resources
 
 tests_require =
     pytest==6.0.1


### PR DESCRIPTION
I found out that this package is missing in `setup.cfg` in section install_requires -- it's caused error while calling 
`from epstats.toolkit.testing import TestData`
`goals = TestData.load_goals_agg(experiment.id)`