### PR TITLE
Fix column name transformer

### DIFF
--- a/docs/user_guide/ab_test_simple_evaluation.ipynb
+++ b/docs/user_guide/ab_test_simple_evaluation.ipynb
@@ -12,10 +12,12 @@
     "\n",
     "## Input DataFrame Example\n",
     "\n",
-    "You should be aware of the following assumptions:\n",
+    "Mind that you need to prepare experiment data on your own. Following example is only illustrative. \n",
+    "\n",
+    "You should be aware of following assumptions:\n",
     "\n",
     "1. First two columns must contain name of the experiment and variants. Names of the columns may vary.\n",
-    "1. It is necessary to download squared values for (continuous) metrics like RPM. If you forget to do it, results will be wrong and misleading. Ep-Stats will not warn you about this issue!\n"
+    "1. It is necessary to download squared values for continuous metrics like Revenue per Mille (RPM). If you forget to do it, results will be wrong and misleading. Ep-Stats will not warn you about this issue!\n"
    ]
   },
   {
@@ -94,6 +96,9 @@
     }
    ],
    "source": [
+    "# This is only example to show required format of the input DataFrame\n",
+    "# You have to prepare aggregated data on your own, e.g. using SQL\n",
+    "\n",
     "from epstats.toolkit.testing import TestData\n",
     "\n",
     "goals = TestData.load_goals_simple_agg()\n",
@@ -104,11 +109,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "For **continous metrics** like **RPM** (RPM = bookings / views * 1000) it is necessary to prepare squared values - in this case we have columns `bookings` and `bookings_squared`. \n",
+    "\n",
+    "Lets assume we have $K$ purchases. Hence the exact definition of columns `bookings` and `bookings_squared` is following\n",
+    "\n",
+    "$$\\text{bookings} = \\sum_{i=1}^{K} \\text{purchase_value}_{i}$$\n",
+    "$$\\text{bookings_squared} = \\sum_{i=1}^{K} (\\text{purchase_value}_{i})^2$$\n",
+    "\n",
+    "This is not necessary for **binary metrics** like **Click-through Rate** or **Conversion Rate**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Experiment Definition and Evaluation\n",
     "\n",
     "Firstly, you need to define metrics you want to evaluate. You can define as many metrics as you want. While creating the instance of the class [`SimpleMetric`](../api/metric.html) you need to specify parameters `id`, `name`, `numerator` and `denominator`. Further you can specify optional parameters `metric_format`, e.g. '${:,.1f}' for RPM, and parameter `metric_value_multiplier`, e.g. 1000 for RPM. The last optional parameter `unit_type` is preset only for technical reason. Be aware there can be used only one `unit_type` within one experiment. The value of this parameter has no impact on the evaluation.\n",
     "\n",
-    "Secondly, you can define checks as well by creating the instance of the class [`SimpleSrmCheck`](../api/check.html).\n",
+    "Secondly, you can define checks as well by creating the instance of the class [`SimpleSrmCheck`](../api/check.html). It is not mandatory to define checks - keep it empty if you do not need one.\n",
     "\n",
     "You wrap both metrics and checks definitions inside the Experiment definition. For more details see [`Experiment`](../api/experiment.html).\n",
     "\n",
@@ -335,6 +354,7 @@
     "    unit_type=unit_type)\n",
     "\n",
     "# Experiment Evaluation\n",
+    "# `goals` is the DataFrame you have prepared on your own, e.g. using SQL\n",
     "ev = experiment.evaluate_wide_agg(goals)\n",
     "\n",
     "# Resluts\n",
@@ -350,7 +370,7 @@
     "\n",
     "You may find useful two methods for nice presentation of results - `results_long_to_wide` and `format_results`.\n",
     "\n",
-    "The former simply convert results from long format to wide one. The later then provide extra tuning. You can set number of decimals defining parameters `format_pct` and `format_pval`.\n"
+    "The former simply convert results from long format to wide one. The later then provide extra tuning. You can set number of decimals defining parameters `format_pct` and `format_pval` respectively.\n"
    ]
   },
   {

--- a/src/epstats/toolkit/experiment.py
+++ b/src/epstats/toolkit/experiment.py
@@ -258,6 +258,8 @@ class Experiment:
 
         It assumes that the first two columns are name of the experiment and variants. Than follows columns with data.
 
+        See usage of the method in the notebook [Ad-hoc A/B test evaluation using Ep-Stats](../user_guide/ab_test_simple_evaluation.html).
+
         Arguments:
             goals: dataframe with one row per variant and aggregated data in columns
 

--- a/src/epstats/toolkit/utils.py
+++ b/src/epstats/toolkit/utils.py
@@ -32,18 +32,18 @@ def goals_wide_to_long(df: pd.DataFrame) -> pd.DataFrame:
 
     # DataFrame `sum_value` to long format
     # Select non squared columns and switch from long to wide
-    cols = [col for col in df.columns.to_list()[2:] if "squared" not in col]
+    cols = [col for col in df.columns.to_list()[2:] if "square" not in col]
     df_long = pd.melt(
         df, id_vars=["exp_id", "exp_variant_id"], value_vars=cols, var_name="goal", value_name="sum_value"
     )
 
     # DataFrame `sum_sqr_value` to long format
     # Select squared columns and swich from long to wide
-    cols_squared = [col for col in df.columns.to_list()[2:] if "squared" in col]
+    cols_squared = [col for col in df.columns.to_list()[2:] if "square" in col]
     df_long_sqr = pd.melt(
         df, id_vars=["exp_id", "exp_variant_id"], value_vars=cols_squared, var_name="goal", value_name="sum_sqr_value"
     )
-    df_long_sqr["goal"] = df_long_sqr["goal"].apply(_change_variable_name)
+    df_long_sqr["goal"] = df_long_sqr["goal"].apply(lambda x: "_".join(x.split("_")[:-1]))
 
     # Merge together and add other necessary columns for evaluation
     goals = pd.merge(left=df_long, right=df_long_sqr, how="outer", on=["exp_id", "exp_variant_id", "goal"])
@@ -57,11 +57,6 @@ def goals_wide_to_long(df: pd.DataFrame) -> pd.DataFrame:
     goals["sum_sqr_value"] = goals.apply(_add_value_squared_where_missing, axis="columns")
 
     return goals
-
-
-def _change_variable_name(variable):
-    """Change variable name, e.g. `transaction_bookings_squared` to `transaction_bookings`."""
-    return variable[:-8]
 
 
 def _add_value_squared_where_missing(row):

--- a/src/epstats/toolkit/utils.py
+++ b/src/epstats/toolkit/utils.py
@@ -60,8 +60,8 @@ def goals_wide_to_long(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _change_variable_name(variable):
-    """Change variable name, e.g. `bookings_squared` to `bookings`."""
-    return variable.split("_")[0]
+    """Change variable name, e.g. `transaction_bookings_squared` to `transaction_bookings`."""
+    return variable[:-8]
 
 
 def _add_value_squared_where_missing(row):


### PR DESCRIPTION
I found a bug in private method `_change_variable_name()`. 

This method worked all right for input `bookings_squared` -- it returned `bookings`. But it failed with input `transaction_bookings_squared`. It returned wrongly `transaction` instead of correctly `transaction_bookings`. 

Now it works all right. It assumes that the input ends with substring `_squared` and nothing else (shorter, or longer), but this assumption is also used in super method `goals_wide_to_long()`.