### PR TITLE
Wide goals df copy and pct formatting

### DIFF
--- a/src/epstats/toolkit/results.py
+++ b/src/epstats/toolkit/results.py
@@ -51,7 +51,7 @@ def _enrich_metric_id(row):
 
 
 def format_results(
-    r: pd.DataFrame, experiment: Experiment, format_pct: str = "{:,.1%}", format_pval: str = "{:,.3f}"
+    r: pd.DataFrame, experiment: Experiment, format_pct: str = "{:+,.1%}", format_pval: str = "{:,.3f}"
 ) -> pd.DataFrame:
     """
     Method formatting wide dataframe with resutls. Using params `format_pct` and `format_pval` you can set number of

--- a/src/epstats/toolkit/utils.py
+++ b/src/epstats/toolkit/utils.py
@@ -27,6 +27,8 @@ def goals_wide_to_long(df: pd.DataFrame) -> pd.DataFrame:
     ```
     """
 
+    # Do not modify the input `df` via reference
+    df = df.copy()
     # Rename first two columns
     df.columns = ["exp_id", "exp_variant_id"] + df.columns.to_list()[2:]
 


### PR DESCRIPTION
* `epstats.toolkit.results.format_results`: Plus sign for positive percentage results
* `epstats.toolkit.utils.goals_wide_to_long`: Do not modify the input df