### PR TITLE
fix unit type in wide goals

### DIFF
--- a/src/epstats/toolkit/experiment.py
+++ b/src/epstats/toolkit/experiment.py
@@ -331,7 +331,7 @@ class Experiment:
         my-exp          d           474934  49090   289             11995       566700
         ```
         """
-        g = goals_wide_to_long(goals)
+        g = goals_wide_to_long(goals, self.unit_type)
         return self.evaluate_agg(g)
 
     def evaluate_by_unit(self, goals: pd.DataFrame) -> Evaluation:

--- a/src/epstats/toolkit/utils.py
+++ b/src/epstats/toolkit/utils.py
@@ -7,12 +7,13 @@ def get_utc_timestamp(dt):
     return mytz.normalize(mytz.localize(dt, is_dst=False))
 
 
-def goals_wide_to_long(df: pd.DataFrame) -> pd.DataFrame:
+def goals_wide_to_long(df: pd.DataFrame, unit_type: str = "test_unit_type") -> pd.DataFrame:
     """
     Modify the input DataFrame in a way that it can be evaluatetd using Experiment.evaluate_agg().
 
     Arguments:
         df: dataframe in wide format - one row per variant and aggregated data in columns
+        unit_type: should be the same value as the `unit_type` passed to `Experiment`
 
     Returns:
         dataframe in long format - one row per variant and goal
@@ -49,7 +50,7 @@ def goals_wide_to_long(df: pd.DataFrame) -> pd.DataFrame:
 
     # Merge together and add other necessary columns for evaluation
     goals = pd.merge(left=df_long, right=df_long_sqr, how="outer", on=["exp_id", "exp_variant_id", "goal"])
-    goals.insert(2, "unit_type", "test_unit_type")
+    goals.insert(2, "unit_type", unit_type)
     goals.insert(3, "agg_type", "global")
     goals.insert(5, "dimension", "")
     goals.insert(6, "dimension_value", "")


### PR DESCRIPTION
There is a bug that produces empty metrics unless experiment `unit_type` is set to `"test_unit_type"` when using `Experiment.evaluate_wide_agg`. It is caused by `"test_unit_type"` [being hardcoded](https://github.com/avast/ep-stats/blob/master/src/epstats/toolkit/utils.py#L52) in `results_long_to_wide`.

Example:
```python
import pandas as pd
from epstats.toolkit import Experiment, SimpleMetric

unit_type = "foo"

goals = pd.DataFrame(
    {
        "experiment_id": "test-exp",
        "exp_variant_id": ["a", "b"],
        "clicks": [1000, 2000],
        "views": [5000, 5000]
    }
)

experiment = Experiment("test-exp", "a",
    [
        SimpleMetric(1, "CTR", "clicks", "views", unit_type),
    ],
    [],
    unit_type=unit_type
)

ev = experiment.evaluate_wide_agg(goals)
print(ev.metrics)
```
Produces
|    |   timestamp | exp_id   |   metric_id | metric_name   | exp_variant_id   |   count |   mean |   std |   sum_value |   confidence_level |   diff |   test_stat |   p_value |   confidence_interval |   standard_error |   degrees_of_freedom |
|---:|------------:|:---------|------------:|:--------------|:-----------------|--------:|-------:|------:|------------:|-------------------:|-------:|------------:|----------:|----------------------:|-----------------:|---------------------:|
|  0 |  1635203932 | test-exp |           1 | CTR           | a                |       0 |    nan |   nan |           0 |               0.95 |    nan |         nan |       nan |                   nan |              nan |                  nan |
|  1 |  1635203932 | test-exp |           1 | CTR           | b                |       0 |    nan |   nan |           0 |               0.95 |    nan |         nan |       nan |                   nan |              nan |                  nan |