### PR TITLE
sample size calculation handles nans/infs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ep-stats
-version = 1.5.0
+version = 1.5.1
 description = Statistical package to evaluate ab tests in experimentation platform.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/epstats/server/res.py
+++ b/src/epstats/server/res.py
@@ -280,7 +280,7 @@ class SampleSizeCalculationResult(BaseModel):
     Result of the sample size calculation.
     """
 
-    sample_size_per_variant: int = Field(
+    sample_size_per_variant: float = Field(
         title="Sample size per variant",
     )
 

--- a/tests/epstats/server/test_api_sample_size_calculation.py
+++ b/tests/epstats/server/test_api_sample_size_calculation.py
@@ -1,4 +1,5 @@
 import pytest
+from math import isnan
 from fastapi.testclient import TestClient
 
 from src.epstats.main import api
@@ -14,7 +15,13 @@ api.dependency_overrides[get_executor_pool] = get_test_executor_pool
 
 @pytest.mark.parametrize(
     "n_variants, minimum_effect, mean, std, expected",
-    [(2, 0.10, 0.2, 1.2, 56512), (2, 0.05, 0.4, None, 9489), (3, 0.05, 0.4, None, 11492)],
+    [
+        (2, 0.10, 0.2, 1.2, 56512),
+        (2, 0.05, 0.4, None, 9489),
+        (3, 0.05, 0.4, None, 11492),
+        (2, 0.1, 0, 0, float("nan")),
+        (2, 0.1, 0, 1, float("inf")),
+    ],
 )
 def test_sample_size_calculation(n_variants, minimum_effect, mean, std, expected):
     json_blob = {
@@ -26,7 +33,12 @@ def test_sample_size_calculation(n_variants, minimum_effect, mean, std, expected
 
     resp = client.post("/sample-size-calculation", json=json_blob)
     assert resp.status_code == 200
-    assert resp.json()["sample_size_per_variant"] == expected
+
+    sample_size = resp.json()["sample_size_per_variant"]
+    if isnan(expected):
+        assert isnan(sample_size)
+    else:
+        assert sample_size == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/epstats/server/test_api_sample_size_calculation.py
+++ b/tests/epstats/server/test_api_sample_size_calculation.py
@@ -35,10 +35,8 @@ def test_sample_size_calculation(n_variants, minimum_effect, mean, std, expected
     assert resp.status_code == 200
 
     sample_size = resp.json()["sample_size_per_variant"]
-    if isnan(expected):
-        assert isnan(sample_size)
-    else:
-        assert sample_size == expected
+
+    assert sample_size == expected or (isnan(expected) and isnan(sample_size))
 
 
 @pytest.mark.parametrize(

--- a/tests/epstats/toolkit/test_statistics.py
+++ b/tests/epstats/toolkit/test_statistics.py
@@ -168,3 +168,24 @@ def test_required_sample_size_per_variant_raises_exception(n_variants, minimum_e
 
     with pytest.raises(ValueError):
         f(**args)
+
+
+@pytest.mark.parametrize(
+    "minimum_effect, mean, std, expected",
+    [
+        (0.1, 0, 0, np.isnan),
+        (0.1, np.nan, np.nan, np.isnan),
+        (0.1, 0, np.nan, np.isnan),
+        (0.1, 0, 1, np.isinf),
+        (np.nan, np.nan, np.nan, np.isnan),
+    ],
+)
+def test_required_sample_size_per_variant_not_valid(minimum_effect, mean, std, expected):
+    assert expected(
+        Statistics.required_sample_size_per_variant(
+            minimum_effect=minimum_effect,
+            mean=mean,
+            std=std,
+            n_variants=2,
+        )
+    )


### PR DESCRIPTION
In case of an invalid input, sample size calculation returns NaN/Inf instead of raising an exception.