### PR TITLE
Make Prometheus work with multiprocess deployments

### DIFF
--- a/src/epstats/main.py
+++ b/src/epstats/main.py
@@ -4,7 +4,7 @@ from pydantic import BaseSettings
 
 from .toolkit.testing import TestDaoFactory, TestData
 from .server import get_api, serve, ApiSettings
-from prometheus_client import make_asgi_app
+from prometheus_client import make_asgi_app, multiprocess, CollectorRegistry
 
 
 class Settings(BaseSettings):
@@ -37,8 +37,15 @@ def get_executor_pool():
         pass
 
 
+def make_metrics_app():
+    registry = CollectorRegistry(auto_describe=True)
+    if settings.api.web_workers > 1:
+        multiprocess.MultiProcessCollector(registry)
+    return make_asgi_app(registry=registry)
+
+
 api = get_api(settings.api, get_dao, get_executor_pool)
-metrics_app = make_asgi_app()
+metrics_app = make_metrics_app()
 api.mount("/metrics", metrics_app)
 
 

--- a/src/epstats/main.py
+++ b/src/epstats/main.py
@@ -38,9 +38,10 @@ def get_executor_pool():
 
 
 def make_metrics_app():
-    registry = CollectorRegistry(auto_describe=True)
-    if settings.api.web_workers > 1:
-        multiprocess.MultiProcessCollector(registry)
+    if settings.api.web_workers == 1:
+        return make_asgi_app()
+    registry = CollectorRegistry()
+    multiprocess.MultiProcessCollector(registry)
     return make_asgi_app(registry=registry)
 
 


### PR DESCRIPTION
When starting the app with multiple uvicorn workers, Prometheus needs a folder in which it can store the metrics. This folder needs to be set in the `PROMETHEUS_MULTIPROC_DIR` environment variable. Best practice is to clear the folder before each start-up of the app.