### PR TITLE
n-ary operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "ep-stats"
-version = "2.5.2"
+version = "2.5.3"
 homepage = "https://github.com/avast/ep-stats"
 description = "Statistical package to evaluate ab tests in experimentation platform."
 authors = [

--- a/tests/epstats/toolkit/test_parser.py
+++ b/tests/epstats/toolkit/test_parser.py
@@ -4,7 +4,7 @@ import pytest
 from numpy.testing import assert_almost_equal
 from pyparsing import ParseException
 
-from src.epstats.toolkit.parser import MultBinOp, Parser
+from src.epstats.toolkit.parser import MultOp, Parser
 
 
 def test_evaluate_agg():
@@ -73,6 +73,21 @@ def test_evaluate_agg():
         goals[goals.goal == "exposure"]["count"].to_numpy() / 1000,
         conversion_value,
         conversion_sqr_value,
+    )
+
+    parser = Parser(
+        """
+        value(test_unit_type.unit.conversion)
+        - value(test_unit_type.unit.refund)
+        - value(test_unit_type.unit.refund)
+        """,
+        "count(test_unit_type.unit.exposure)",
+    )
+    assert_count_value(
+        parser.evaluate_agg(goals),
+        goals[goals.goal == "exposure"]["count"],
+        conversion_value - refund_value - refund_value,
+        conversion_sqr_value - refund_sqr_value - refund_sqr_value,
     )
 
 
@@ -357,7 +372,7 @@ def test_operator_position_not_correct(dimension_value):
 def test_numbers(nominator):
     assert isinstance(
         Parser(nominator, "count(test_unit_type.unit.conversion)")._nominator_expr,
-        MultBinOp,
+        MultOp,
     )
 
 


### PR DESCRIPTION
Fixes a bug where arithmetic operations with more then two goals such as `count(randomization_unit.unit.goal_1) - count(randomization_unit.unit.goal_2) - count(randomization_unit.unit.goal_3)` ignore the third and any following goal.